### PR TITLE
build(deps): drop the adm-zip overrides pin (upstream ranges reach 0.6.0)

### DIFF
--- a/opendia-extension/package.json
+++ b/opendia-extension/package.json
@@ -26,7 +26,6 @@
     "web-ext": "^10.6.0"
   },
   "overrides": {
-    "adm-zip": "^0.6.0",
     "brace-expansion": "^1.1.16",
     "shell-quote": "^1.9.0"
   }


### PR DESCRIPTION
## What

Removes the `adm-zip` `overrides` pin in `opendia-extension/package.json`, added by #56 as a stopgap for [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85). Tracked in #58.

## Why now — both upstream gates cleared

| gate | when #58 was filed | now |
|---|---|---|
| firefox-profile adm-zip range | `4.7.0` → `~0.5.x` (unreachable) | **`4.7.1` → `~0.6.x`** |
| web-ext firefox-profile pin | `10.5.0` → exact `4.7.0` | **`10.6.0` → `4.7.1`** |

`adm-zip` latest is `0.6.0`, so firefox-profile's own `~0.6.x` now resolves the patched version natively — the override is redundant.

## Safety

Resolution is **byte-identical** with vs without the override: `npm install --package-lock-only` produces **no lockfile change**, and the tree still resolves `adm-zip@0.6.0`. The unrelated `brace-expansion` / `shell-quote` overrides are untouched.

## Verified locally (extension CI steps, from #58's checklist)

- `npm ci` → exit 0 (lock satisfies package.json)
- `npm run build` → chrome + firefox built
- `node build.js validate` → both builds pass
- `node test-extension.js` → pass
- `npx web-ext lint --source-dir=dist/firefox --self-hosted` → **0 errors** (3 pre-existing warnings)
- `npm audit` → GHSA-xcpc-8h2w-3j85 no longer present

Closes #58.
