### PR TITLE
Add founder credit + link to aaronjmars.com

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -393,3 +393,7 @@ MIT License - see [LICENSE](../LICENSE) for details.
 ---
 
 **Ready to supercharge your browser with AI? Get started with `npx opendia`! 🚀**
+
+---
+
+Built by [Aaron Elijah Mars](https://aaronjmars.com), founder of Aeon and MiroShark · [@aaronjmars](https://github.com/aaronjmars)


### PR DESCRIPTION
Adds a footer credit linking back to the personal hub, so the profile <-> project link is reciprocal (what makes a sameAs edge count).

One line appended to the README; no other change.